### PR TITLE
Update repository URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ I'll create a better guide explaining features and do proper versioning, just do
 
 ```
 cd themes
-git clone https://gitlab.com/mertbakir/resume-a4.git
+git clone https://github.com/mertbakir/resume-a4.git
 ```
 
 or add as a submodule
 
 ```
-git submodule add https://gitlab.com/mertbakir/resume-a4.git themes/resume-a4
+git submodule add https://github.com/mertbakir/resume-a4.git themes/resume-a4
 ```
 
 ## Start


### PR DESCRIPTION
Hey @mertbakir 

Just a quick fix of the repository URLs used in the clone and submodule examples in the README.

(Took me way longer then I'm willing to admit to notice when I tried getting the latest version of the theme)